### PR TITLE
Update CMake min version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0)
 project(xtensor_ros)
 
 macro(use_cxx14)


### PR DESCRIPTION
Modern CMake 3.0 ﻿has been out for quite a long time.

https://repology.org/project/cmake/versions shows that all platforms either distribute a version 3
or have a version 3 alternative.

Reason for switching to v3.0: CMake now shows noisy warnings for 2.x min version
